### PR TITLE
Add "crop and scale" option

### DIFF
--- a/2.1/__init__.py
+++ b/2.1/__init__.py
@@ -140,7 +140,18 @@ def resize(im):
     widthInConfig = int(Setup.config['width'])
     transformationMode = Qt.FastTransformation if (Setup.config['scalingMode'] == 'fast') else Qt.SmoothTransformation
 
-    if option == 'height' or option == 'either' and im.width() <= im.height():
+    if option == 'crop':
+        imageRatio = im.width() / im.height()
+        targetRatio = widthInConfig / heightInConfig
+        width = im.width() if targetRatio > imageRatio else im.height() * targetRatio
+        height = im.height() if targetRatio < imageRatio else im.width() // targetRatio
+        widthOffset = (im.width() - width) // 2
+        heightOffset = (im.height() - height) // 2
+        rect = QRect(widthOffset, heightOffset, width, height)
+        logger.debug('crop image, width: {}, height: {}'.format(width, height))
+        im = im.copy(rect)
+
+    if option == 'height' or option == 'either' and im.width() <= im.height() or option == 'crop':
         if im.height() <= heightInConfig and not isUpScalingDisabled or im.height() > heightInConfig:
             logger.debug('scale according to height: {}'.format(int(Setup.config['height'])))
             im = im.scaledToHeight(heightInConfig, transformationMode)
@@ -148,7 +159,7 @@ def resize(im):
         if im.width() <= widthInConfig and not isUpScalingDisabled or im.width() > widthInConfig:
             logger.debug('scale according to width: {}'.format(int(Setup.config['width'])))
             im = im.scaledToWidth(widthInConfig, transformationMode)
-        
+
     logger.debug('image after resizing, width: {}, height: {}'.format(im.width(), im.height()))
     return im
 
@@ -360,6 +371,8 @@ class Settings(QWidget):
             Setup.config['ratioKeep'] = 'width'
         elif self.ratioCb.currentIndex() == 2:
             Setup.config['ratioKeep'] = 'either'
+        elif self.ratioCb.currentIndex() == 3:
+            Setup.config['ratioKeep'] = 'crop'
         if self.scalingCb.currentIndex() == 0:
             Setup.config['scalingMode'] = 'fast'
         elif self.scalingCb.currentIndex() == 1:
@@ -395,6 +408,8 @@ class Settings(QWidget):
             self.ratioCb.setCurrentIndex(1)
         elif Setup.config['ratioKeep'] == 'either':
             self.ratioCb.setCurrentIndex(2)
+        elif Setup.config['ratioKeep'] == 'crop':
+            self.ratioCb.setCurrentIndex(3)
         self.setLineEditState()
         if Setup.config['scalingMode'] == 'fast':
             self.scalingCb.setCurrentIndex(0)
@@ -466,6 +481,7 @@ class Settings(QWidget):
         self.ratioCb.addItem('scale to height and keep ratio')
         self.ratioCb.addItem('scale to width and keep ratio')
         self.ratioCb.addItem('scale to the maximum dimension and keep ratio')
+        self.ratioCb.addItem('crop and scale')
         # QObject.connect(self.ratioCb, SIGNAL("currentIndexChanged(int)"), self.setLineEditState)
         self.ratioCb.currentIndexChanged.connect(self.setLineEditState)
 
@@ -527,6 +543,9 @@ class Settings(QWidget):
             self.disableLineEdit(self.heightEdit)
             self.enableLineEdit(self.widthEdit)
         elif self.ratioCb.currentIndex() == 2:
+            self.enableLineEdit(self.heightEdit)
+            self.enableLineEdit(self.widthEdit)
+        elif self.ratioCb.currentIndex() == 3:
             self.enableLineEdit(self.heightEdit)
             self.enableLineEdit(self.widthEdit)
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ There's also a third option, `scale to the maximum dimension and keep ratio`.
 If this option is chosen, ImageResizer will scale to width if width > height,
 and will scale to height if height > width.
 This option is useful when the ratio of height/width of the image is extreme.
+Fourth option `crop and scale` change the image's ratio by cropping and then
+resizes it.


### PR DESCRIPTION
Problem: if we use `scale to height` or `scale to width` and paste more than one image, images could look kind of sloppy because of different aspect ratios.
<img width="1380" alt="out" src="https://user-images.githubusercontent.com/1645383/82069760-13f0c200-96d4-11ea-95a6-ffa8536bf4bd.png">


`crop and scale` option solves this problem, although it loses some parts of the image:
<img width="690" alt="Bildschirmfoto 2020-05-15 um 17 36 00" src="https://user-images.githubusercontent.com/1645383/82068972-fec76380-96d2-11ea-97b6-c2758186f4ec.png">


